### PR TITLE
fix: Update CODEOWNERS from original scaffolding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashicorp/terraform-devex
+* @denoland/engineering


### PR DESCRIPTION
Update CODEOWNERS. Also, via Github UI, add denoland/engineering team as maintainers to this repository.