### PR TITLE
chore: remove engineering from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @denoland/engineering
+


### PR DESCRIPTION
Just see we don't all get asked to give a review on every PR in this repo. Maybe we could create a deploy team or perhaps add specific people to this file in the future?