### PR TITLE
fix: Update provider names to match registry location

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,27 @@ a Deno deploy organization ID and an access token. See `docs/index.md` for
 instructions on finding or creating those values.
 
 Resource and schema documentation still needs to be written. In the interim,
-API documentation is available at https://deno-deploy-v1.redoc.ly/. Resources
-are strongly aligned to the API.
+API documentation is available at https://maguro-rapidoc.deno.dev/. Resources
+are aligned with the API.
 
+If you want to build and run the provider locally, you can override where
+terraform finds the provider. The override is configured in $HOME/.terraformrc.
+
+```terraform.rc
+provider_installation {
+
+  dev_overrides {
+      "registry.terraform.io/denoland/deno" = "/Users/<username>/go/bin"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+```
+
+With this set (assuming your go binary install location is $HOME/go/bin), 
+you can `go install` the provider and use the locally built version vs.
+the registry published version. (Note that the override doesn't seem to
+resolve environment variables, so `$HOME/go/bin` will not work.)

--- a/examples/assets-data-source-verification/main.tf
+++ b/examples/assets-data-source-verification/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     deno = {
-      source = "github.com/denoland/deno"
+      source = "denoland/deno"
     }
   }
 }

--- a/examples/deployment-verification/main.tf
+++ b/examples/deployment-verification/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     deno = {
-      source = "github.com/denoland/deno"
+      source = "denoland/deno"
     }
   }
 }

--- a/examples/provider-install-verification/main.tf
+++ b/examples/provider-install-verification/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     deno = {
-      source = "github.com/denoland/deno"
+      source = "denoland/deno"
     }
 
     cloudflare = {

--- a/main.go
+++ b/main.go
@@ -39,8 +39,9 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		// Todo: unsure what form is publishable to the Hashicorp TF registry
-		Address: "github.com/denoland/deno",
+		// This should match the Hashicorp Terraform registry name (denoland/deno).
+		// That name, in turn, uses the organization name (denoland) from github.
+		Address: "registry.terraform.io/denoland/deno",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
With the provider published, update the registry location to match the registry location (registry.terraform.io/denoland/deno). Update the examples accordingly.
Update the readme with a pointer to the auto-generated API documentation. Update the readme with instructions on using the terraform dev-override to run a local version of the provider.