### PR TITLE
fix(assets, deployment): perform another deployment on file change

### DIFF
--- a/docs/data-sources/assets.md
+++ b/docs/data-sources/assets.md
@@ -50,5 +50,6 @@ If this field is omitted, the assets will be put under the "." directory in the 
 Read-Only:
 
 - `content_source_path` (String) The file path of the asset in the local filesystem.
+- `git_sha1` (String) The git SHA1 of the asset. It is only available for `file` asset.
 - `kind` (String) The kind of the asset. It can be either `file` or `symlink`.
 - `target` (String) The target file path of the symlink in the the runtime virtual filesystem. It is only available for `symlink` asset.

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -108,6 +108,7 @@ Optional:
 - `content` (String) The inlined content of the asset. This is valid only for `file` asset. If both `content` and `content_source_path` are specified, it will error out.
 - `content_source_path` (String) The file path of the asset in the local filesystem.
 - `encoding` (String) The encoding of the inlined content. This takes effect only when `content` is present. Possible values are `utf-8` and `base64`. If omitted, the content will be interpreted as `utf-8`.
+- `git_sha1` (String) The git SHA1 of the asset. It is only available for `file` asset.
 - `target` (String) The target file path of the symlink in the the runtime virtual filesystem. It is only available for `symlink` asset.
 
 


### PR DESCRIPTION
This commit adds `git_sha1` attribute to both the output of `deno_assets` and the input of `deno_deployment`. When we make a change to a file in the assets the hash value changes, which in turn lets terraform create a new deployment.

Fixes #36 